### PR TITLE
Hide sidebar by default on mobile and arrange statuses in a column

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -27,14 +27,19 @@ type BoardProps = {
 
 export default function Board({ initialProjects }: BoardProps) {
   const { prefs, toggleStatus, toggleCardField } = useBoardPreferences()
+  const { mode } = useAppModeContext()
+
   const [isProjectModalShellOpen, setIsProjectModalShellOpen] = useState(false)
   const [isEditProjectModalOpen, setIsEditProjectModalOpen] = useState(false)
   const [initialStatus, setInitialStatus] = useState<ProjectStatus>("inquiry")
   const [projects, setProjects] = useState<Project[]>(initialProjects)
   const [projectToEdit, setProjectToEdit] = useState<Project>()
-  const [isSideBarOpen, setIsSidebarOpen] = useState(true)
-
-  const { mode } = useAppModeContext()
+  const [isSideBarOpen, setIsSidebarOpen] = useState(() => {
+    if (typeof window !== "undefined") {
+      return window.innerWidth >= 768
+    }
+    return true
+  })
 
   const { handleStatusChange } = useProjectActions({ mode })
 
@@ -111,7 +116,7 @@ export default function Board({ initialProjects }: BoardProps) {
   }, [projects])
 
   return (
-    <div className="flex w-full min-h-[32rem] min-h-full flex-row overflow-x-hidden rounded-xl bg-board max-md:min-h-[24rem] max-md:rounded-none">
+    <div className="flex w-full min-h-[32rem] min-h-full flex-row overflow-x-hidden rounded-xl bg-board max-md:min-h-[24rem] max-md:min-h-full max-md:rounded-none">
       <div className="flex min-w-0 flex-1 flex-col">
         <header className="px-6 py-4 max-md:px-3 max-md:py-3">
           <div className="flex flex-col items-start justify-between">

--- a/src/components/StatusFilterBar.tsx
+++ b/src/components/StatusFilterBar.tsx
@@ -11,7 +11,7 @@ export default function StatusFilterBar({
   toggleStatus: (status: ProjectStatus) => void
 }) {
   return (
-    <div className="flex gap-8 py-6 px-8 max-md:grid max-md:grid-cols-3 max-md:gap-4 max-md:px-4">
+    <div className="flex gap-8 py-6 px-8 max-md:grid max-md:grid-cols-1 max-md:gap-4 max-md:px-4">
       {statuses.map((status) => (
         <FilterItem
           key={status}


### PR DESCRIPTION
Closes #43 

This pull request makes improvements to the responsiveness and user experience of the board and status filter components. The main changes focus on better sidebar initialization based on screen size, enhanced mobile layout handling, and improved filter bar responsiveness.

**Board component improvements:**

* Sidebar initialization now checks the window width on load, so the sidebar starts closed on small screens and open on larger screens, improving mobile usability.
* The board container layout is updated to ensure the minimum height is properly set for mobile devices, preventing layout issues.

**Status filter bar improvements:**

* The filter bar switches to a single-column grid layout on mobile screens, making filter options easier to use and more visually accessible on smaller devices.